### PR TITLE
MS-16: Improved layout

### DIFF
--- a/client/src/common/components/layout/main-layout/_main-layout.module.scss
+++ b/client/src/common/components/layout/main-layout/_main-layout.module.scss
@@ -1,6 +1,7 @@
 @import "assets/theme/constants.module.scss";
 
 .master-container {
+  height: 100%;
 }
 
 .main-content {

--- a/client/src/features/auth/components/layout/auth-layout/_auth-layout.module.scss
+++ b/client/src/features/auth/components/layout/auth-layout/_auth-layout.module.scss
@@ -4,7 +4,7 @@
   background-color: $color-secondary-caramelMilk;
   display: flex;
   justify-content: center;
-  height: 100vh;
+  height: 100%;
   width: 100%;
 }
 
@@ -12,7 +12,8 @@
   display: flex;
   flex-direction: column;
   gap: 2em;
-  margin-top: 10em;
+  align-items: center;
+  justify-content: center;
 }
 
 .miss-strawberry-image {

--- a/client/src/features/feature-manager/_feature-manager.module.scss
+++ b/client/src/features/feature-manager/_feature-manager.module.scss
@@ -6,7 +6,7 @@
 .new-recipe {
   // display: flex;
 
-  height: 100vh;
+  height: 100%;
   // gap: $main-layout-spacing;
 }
 

--- a/client/src/features/recipe/create/create-recipe/_create-recipe.module.scss
+++ b/client/src/features/recipe/create/create-recipe/_create-recipe.module.scss
@@ -4,9 +4,15 @@
 .recipe-card-container {
   width: 75em;
   margin: auto;
+  height: 100%;
+  // height: fit-content;
+  position: relative;
 }
 
 .new-recipe-head {
+  z-index: 1000;
+  width: 75em;
+  position: fixed;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -48,6 +54,8 @@
 }
 
 .body {
+  overflow: scroll;
+  margin-top: 3.5em;
   display: flex;
   flex-direction: column;
   gap: $inner-window-spacing-small;

--- a/client/src/features/recipe/view/view-recipe/_view-recipe.module.scss
+++ b/client/src/features/recipe/view/view-recipe/_view-recipe.module.scss
@@ -2,7 +2,7 @@
 @import "assets/theme/mixins.scss";
 
 .recipe-card-master {
-  height: fit-content;
+  height: 100%;
 }
 
 .header-main {
@@ -51,6 +51,7 @@
 }
 
 .recipe-body {
+  overflow: scroll;
   display: flex;
   flex-direction: column;
   gap: $inner-window-spacing-small;

--- a/client/src/features/results/_results.module.scss
+++ b/client/src/features/results/_results.module.scss
@@ -14,7 +14,7 @@
 }
 
 .master-window-results {
-  height: 100vh;
+  height: 100%;
 }
 
 .master-window-no-results {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -7,9 +7,18 @@ body {
   -moz-osx-font-smoothing: grayscale;
   overscroll-behavior-y: none;
   overscroll-behavior-x: none;
+  height: 100%;
 }
 
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
     monospace;
+}
+
+html {
+  height: 100%;
+}
+
+#root {
+  height: 100%;
 }


### PR DESCRIPTION
## Description

[MS-16](https://rupertwebdev.atlassian.net/browse/MS-16): Fixed the layout of recipe and results cards. Corrected the auth layout for smaller screens

### Modified: 

`client/src/features/auth/components/layout/auth-layout/_auth-layout.module.scss`: Changed as a better solution to centre the main content. Specifically this solution is a better workaround for smaller sized screens. 

`client/src/features/feature-manager/_feature-manager.module.scss`: For whatever reason, % instead of vh helps to contain the content on the page and prevent overflow 

`client/src/features/results/_results.module.scss`: For whatever reason, % instead of vh helps to contain the content on the page and prevent overflow 

### Added:

`client/src/common/components/layout/main-layout/_main-layout.module.scss`: Added to prevent the cards from overflowing  

`client/src/features/recipe/create/create-recipe/_create-recipe.module.scss`: Here, instead of allowing the recipe card to overflow, it is contained on the window. Any content that needs to extend beyond the boundaries of the card is instead accessible by scrolling.

`client/src/features/recipe/view/view-recipe/_view-recipe.module.scss`: As with "create-recipe" above we are doing the exact same thing here with "view-recipe" 

`client/src/index.css`: In order to ensure the background, whether this is a fill or an image, extends the full height, we extend the height of all root components to be 100%

### Deleted:

None