### PR TITLE
MS-17: Persist state in local storage on user refresh. Remove state on log out 

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10355,6 +10355,11 @@
         "@babel/runtime": "^7.9.2"
       }
     },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ=="
+    },
     "redux-thunk": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.4.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "react-simple-star-rating": "^5.1.7",
     "react-textarea-autosize": "^8.4.0",
     "reactjs-popup": "^2.0.5",
+    "redux-persist": "^6.0.0",
     "sass": "^1.54.4",
     "typescript": "^4.7.4",
     "web-vitals": "^2.1.4"

--- a/client/src/features/auth/logout/hooks/use-handle-logout.ts
+++ b/client/src/features/auth/logout/hooks/use-handle-logout.ts
@@ -8,6 +8,7 @@ export default function useHandleLogout() {
   const handleLogout = () => {
     function callSuccess(logoutData: any) {
       navigate("/login");
+      localStorage.clear();
       window.location.reload();
     }
 

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -5,6 +5,8 @@ import { Provider } from "react-redux";
 import missStrawberryStore from "store";
 import { PopupContextProvider } from "common/popup/store/popup-context";
 import { WindowContextProvider } from "common/components/window/store/window-context";
+import { PersistGate } from "redux-persist/integration/react";
+import { persistor } from "store";
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -13,7 +15,9 @@ root.render(
   <Provider store={missStrawberryStore}>
     <PopupContextProvider>
       <WindowContextProvider>
-        <MissStrawberryApp />
+        <PersistGate loading={null} persistor={persistor}>
+          <MissStrawberryApp />
+        </PersistGate>
       </WindowContextProvider>
     </PopupContextProvider>
   </Provider>

--- a/client/src/react-app-env.d.ts
+++ b/client/src/react-app-env.d.ts
@@ -4,3 +4,8 @@ declare module "*.mp3" {
   const src: string;
   export default src;
 }
+
+declare module "redux-persist/lib/storage" {
+  const storage: any;
+  export default storage;
+}

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -8,20 +8,34 @@ import audioSlice from "common/store/audio-slice";
 import profileSettingsSlice from "common/store/profile-settings-slice";
 import resultsSlice from "features/results/store/results-slice";
 import headerSidebarSlice from "common/store/header-sidebar-slice";
+import storage from "redux-persist/lib/storage";
+import { persistStore, persistReducer } from "redux-persist";
+import { combineReducers } from "@reduxjs/toolkit";
+
+const rootReducer = combineReducers({
+  cards: cardsReducer,
+  auth: authReducer,
+  createRecipe: createRecipeReducer,
+  recipes: recipesReducer,
+  recipeLayout: recipeLayoutSlice,
+  audio: audioSlice,
+  profileSettings: profileSettingsSlice,
+  results: resultsSlice,
+  sidebarHeader: headerSidebarSlice,
+});
+const persistConfig = {
+  key: "root",
+  storage,
+  // whitelist: ["auth", "results", "cards", "results", ], // only persist the 'auth' slice of state
+};
+
+const persistedReducer = persistReducer(persistConfig, rootReducer);
 
 const missStrawberryStore = configureStore({
-  reducer: {
-    cards: cardsReducer,
-    auth: authReducer,
-    createRecipe: createRecipeReducer,
-    recipes: recipesReducer,
-    recipeLayout: recipeLayoutSlice,
-    audio: audioSlice,
-    profileSettings: profileSettingsSlice,
-    results: resultsSlice,
-    sidebarHeader: headerSidebarSlice,
-  },
+  reducer: persistedReducer,
 });
+
+export const persistor = persistStore(missStrawberryStore);
 
 export default missStrawberryStore;
 


### PR DESCRIPTION
## Description

[MS-17](https://rupertwebdev.atlassian.net/browse/MS-17): State is persisted in local storage to prevent the application from "restarting" after a page refresh. When user logs out, the state is removed from local storage. 

### Modified: 

`client/src/index.tsx`: From ChatGPT: "Wrap your root component with the PersistGate component from redux-persist to wait for the store to be rehydrated from local storage before rendering the component"

`client/src/store/index.ts`: Reformatting the root store to persist data. From ChatGPT: 

"persistReducer is used to wrap the root reducer and create a new persisted reducer. The persistConfig object specifies the key to use for the persisted data in local storage (in this case, 'root') and the storage mechanism to use (in this case, redux-persist/lib/storage, which uses local storage by default). 'persistStore' is used to create a persisted version of the store, which allows the store to be rehydrated from local storage when the page is refreshed."

### Added:

`client/package.json`: Added "redux-persist" module, to persist redux state in local storage 

`client/src/features/auth/logout/hooks/use-handle-logout.ts`: Clear local storage on log out 

`client/src/react-app-env.d.ts`: Enable redux-persist types 

### Deleted:

None